### PR TITLE
Fix loader xml encoding

### DIFF
--- a/xml/lang/en.xml
+++ b/xml/lang/en.xml
@@ -1,4 +1,4 @@
-﻿<lang id="en" debug="0">
+<lang id="en" debug="0">
 	<statics>
 		<!-- STATICS -->
 		<t id="1"	v="Level"/>

--- a/xml/lang/es.xml
+++ b/xml/lang/es.xml
@@ -1,4 +1,4 @@
-﻿<lang id="es">
+<lang id="es">
 	<statics>
 		<!-- STATICS -->
 		<t id="1"	v="Nivel"/>

--- a/xml/lang/fr.xml
+++ b/xml/lang/fr.xml
@@ -1,4 +1,4 @@
-﻿<lang id="fr" debug="0">
+<lang id="fr" debug="0">
 	<statics>
 		<!-- STATICS -->
 		<t id="1"	v="Niveau"/>

--- a/xml/quests.xml
+++ b/xml/quests.xml
@@ -1,4 +1,4 @@
-﻿<quests>
+<quests>
 
 	<!-- signes zodiaque -->
 	<quest id="0">

--- a/xml/scoreItems.xml
+++ b/xml/scoreItems.xml
@@ -1,4 +1,4 @@
-﻿<items>
+<items>
 	<family id="1000"> <!-- petites gateries -->
 		<item id="1000"	rarity="0"	value="--" />
 		<item id="1003"	rarity="1"	value="500" />

--- a/xml/specialItems.xml
+++ b/xml/specialItems.xml
@@ -1,4 +1,4 @@
-﻿<items>
+<items>
 	<family id="0"> <!-- items de base -->
 		<item id="0"	rarity="0" />
 		<item id="3"	rarity="2" />


### PR DESCRIPTION
This PR removes non-printable characters found at the beginning of some xml files.  
This characters made the compiler crash with the following error :

```
Error : Error in xml/lang/fr.xml : End of file expected line 1 characters 24-26
```